### PR TITLE
fix(dev): bun run dev no longer requires TELEGRAM_BOT_TOKEN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to omp-deck. The format is loosely based on
 
 ## [Unreleased]
 
+### Fixed
+
+- Fresh-clone `bun run dev` no longer fails on missing `TELEGRAM_BOT_TOKEN`. The root `dev` script was fanning out across every workspace (`--filter='@omp-deck/*'`) and bringing the standalone telegram bridge along with the deck server + web — the bridge's config validator throws if no bot token is set, so first-run users would hit an error before the UI ever came up. The bridge has always been opt-in (Settings → Messaging → Start, or `bun run dev:telegram`); the dev script now restricts itself to `@omp-deck/server` + `@omp-deck/web` to match the documented behavior in `CONTRIBUTING.md`.
+
 ## [0.3.0] — V1 routines, V2 canvas, reliability + notifications, orientation + chat polish
 
 Three big surfaces (V1 routines, V2 canvas builder, reliability + notification stack) land alongside a wave of smaller refinements (kanban polish, ask-tool bridge, starter skills, orientation Settings, queued prompts, kb:// resolution, image paste, app icon).

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "bun run --filter='@omp-deck/*' dev",
+    "dev": "bun run --filter '@omp-deck/server' --filter '@omp-deck/web' dev",
     "dev:server": "bun run --filter '@omp-deck/server' dev",
     "dev:web": "bun run --filter '@omp-deck/web' dev",
     "dev:telegram": "bun run --filter '@omp-deck/telegram-bridge' dev",


### PR DESCRIPTION
## Problem

Reported issue: `bun run dev` errors out on a fresh clone with a missing `TELEGRAM_BOT_TOKEN`.

Root `dev` script was `bun run --filter='@omp-deck/*' dev`, which fans out across every workspace including the standalone telegram-bridge. The bridge's config validator throws on missing token, so first-run users following the documented clone -> `bun i` -> `bun run dev` flow hit an opaque error before the UI ever comes up.

## Fix

Scope the `dev` filter to `@omp-deck/server` + `@omp-deck/web`. The telegram bridge has always been opt-in (Settings -> Messaging -> Start, or `bun run dev:telegram`); CONTRIBUTING.md already documents `bun run dev` as 'server (8787) + vite (5173) in parallel'. The script now matches the docs.

`dev:telegram` is unchanged and remains the explicit way to bring the bridge up once the bot token + allowlist are set.

## Diff

```diff
-    "dev": "bun run --filter='@omp-deck/*' dev",
+    "dev": "bun run --filter '@omp-deck/server' --filter '@omp-deck/web' dev",
```

Plus a CHANGELOG entry.

## Verification

- `bun run --filter '@omp-deck/server' --filter '@omp-deck/web' typecheck` runs both, skips the bridge.
- Multi-`--filter` syntax confirmed working in the pinned Bun (1.3.14).
- `bun run typecheck` and `bun run dev:telegram` are unaffected — bridge still typechecks via the workspace-wide pattern, and the explicit script still validates env on demand.

## Note

Spotted concurrent uncommitted WIP on `apps/bridges/telegram/src/{config,index}.ts` + `docs/telegram.md` improving the bridge's error message when `dev:telegram` runs without env. That's complementary to this fix (this PR prevents the error from ever firing during default `dev`; that WIP makes the explicit-bridge-startup error actionable) and intentionally left untouched on the working tree for the author to finish + commit separately.