### PR TITLE
fix(routines): stabilize step editing and webhook saves

### DIFF
--- a/apps/server/src/db/routine-step-runs.test.ts
+++ b/apps/server/src/db/routine-step-runs.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { closeDb, getDb, openDb } from "./index.ts";
+import {
+	deleteWebhookSecret,
+	ensureWebhookSecret,
+	getWebhookSecretByPath,
+	upsertWebhookSecret,
+} from "./routine-step-runs.ts";
+
+let dbDir: string | null = null;
+
+afterEach(() => {
+	closeDb();
+	if (dbDir) {
+		try {
+			fs.rmSync(dbDir, { recursive: true, force: true });
+		} catch {
+			// SQLite handles can lag after close on some platforms; leaking a temp dir
+			// is better than making an unrelated test fail.
+		}
+		dbDir = null;
+	}
+});
+
+function bootDb(): void {
+	dbDir = fs.mkdtempSync(path.join(os.tmpdir(), "omp-deck-webhook-db-"));
+	openDb({ path: path.join(dbDir, "deck.db") });
+}
+
+function insertRoutine(id: string): void {
+	const now = new Date().toISOString();
+	getDb()
+		.prepare<unknown, [string, string, string, string]>(
+			`INSERT INTO routines (id, name, description, cron, action_kind, action_body, created_at, updated_at)
+			 VALUES (?, ?, '', '', 'bash', '', ?, ?)`,
+		)
+		.run(id, id, now, now);
+}
+
+describe("routine webhook secrets", () => {
+	test("upsert reports path conflicts instead of throwing SQLITE_CONSTRAINT_UNIQUE", () => {
+		bootDb();
+		insertRoutine("r_one");
+		insertRoutine("r_two");
+
+		expect(upsertWebhookSecret({ routineId: "r_one", path: "/hooks/shared", secretHash: "h1" })).toBe(true);
+		expect(upsertWebhookSecret({ routineId: "r_two", path: "/hooks/shared", secretHash: "h2" })).toBe(false);
+
+		expect(getWebhookSecretByPath("/hooks/shared")?.routine_id).toBe("r_one");
+		expect(getWebhookSecretByPath("/hooks/shared")?.secret_hash).toBe("h1");
+	});
+
+	test("ensure is idempotent on save and does not rotate existing secrets", () => {
+		bootDb();
+		insertRoutine("r_one");
+
+		expect(ensureWebhookSecret({ routineId: "r_one", path: "/hooks/one", secretHash: "initial" })).toBe(true);
+		expect(ensureWebhookSecret({ routineId: "r_one", path: "/hooks/one", secretHash: "new-save-secret" })).toBe(true);
+
+		expect(getWebhookSecretByPath("/hooks/one")?.secret_hash).toBe("initial");
+	});
+
+	test("ensure moves a routine registration to a new free path without changing the secret", () => {
+		bootDb();
+		insertRoutine("r_one");
+
+		expect(ensureWebhookSecret({ routineId: "r_one", path: "/hooks/old", secretHash: "initial" })).toBe(true);
+		expect(ensureWebhookSecret({ routineId: "r_one", path: "/hooks/new", secretHash: "ignored" })).toBe(true);
+
+		expect(getWebhookSecretByPath("/hooks/old")).toBeUndefined();
+		expect(getWebhookSecretByPath("/hooks/new")?.routine_id).toBe("r_one");
+		expect(getWebhookSecretByPath("/hooks/new")?.secret_hash).toBe("initial");
+	});
+
+	test("delete removes stale registrations when a routine no longer has a webhook trigger", () => {
+		bootDb();
+		insertRoutine("r_one");
+
+		expect(ensureWebhookSecret({ routineId: "r_one", path: "/hooks/one", secretHash: "initial" })).toBe(true);
+		deleteWebhookSecret("r_one");
+
+		expect(getWebhookSecretByPath("/hooks/one")).toBeUndefined();
+	});
+});

--- a/apps/server/src/db/routine-step-runs.ts
+++ b/apps/server/src/db/routine-step-runs.ts
@@ -183,7 +183,9 @@ export function upsertWebhookSecret(input: {
 	routineId: string;
 	path: string;
 	secretHash: string;
-}): void {
+}): boolean {
+	if (isWebhookPathClaimedByAnotherRoutine(input.path, input.routineId)) return false;
+
 	const now = nowIso();
 	getDb()
 		.prepare<unknown, [string, string, string, string]>(
@@ -195,6 +197,42 @@ export function upsertWebhookSecret(input: {
 			   created_at = excluded.created_at`,
 		)
 		.run(input.routineId, input.path, input.secretHash, now);
+	return true;
+}
+
+export function ensureWebhookSecret(input: {
+	routineId: string;
+	path: string;
+	secretHash: string;
+}): boolean {
+	if (isWebhookPathClaimedByAnotherRoutine(input.path, input.routineId)) return false;
+
+	const existing = getWebhookSecretByRoutine(input.routineId);
+	if (existing) {
+		if (existing.path !== input.path) {
+			getDb()
+				.prepare<unknown, [string, string]>(
+					"UPDATE routine_webhook_secrets SET path = ? WHERE routine_id = ?",
+				)
+				.run(input.path, input.routineId);
+		}
+		return true;
+	}
+
+	const now = nowIso();
+	getDb()
+		.prepare<unknown, [string, string, string, string]>(
+			`INSERT INTO routine_webhook_secrets (routine_id, path, secret_hash, created_at)
+			 VALUES (?, ?, ?, ?)`,
+		)
+		.run(input.routineId, input.path, input.secretHash, now);
+	return true;
+}
+
+export function deleteWebhookSecret(routineId: string): void {
+	getDb()
+		.prepare<unknown, [string]>("DELETE FROM routine_webhook_secrets WHERE routine_id = ?")
+		.run(routineId);
 }
 
 export function getWebhookSecretByPath(path: string): WebhookSecretRow | undefined {
@@ -204,6 +242,20 @@ export function getWebhookSecretByPath(path: string): WebhookSecretRow | undefin
 		)
 		.get(path) as WebhookSecretRow | null;
 	return row ?? undefined;
+}
+
+function getWebhookSecretByRoutine(routineId: string): WebhookSecretRow | undefined {
+	const row = getDb()
+		.query<WebhookSecretRow, [string]>(
+			"SELECT routine_id, path, secret_hash, created_at, last_used_at FROM routine_webhook_secrets WHERE routine_id = ?",
+		)
+		.get(routineId) as WebhookSecretRow | null;
+	return row ?? undefined;
+}
+
+function isWebhookPathClaimedByAnotherRoutine(path: string, routineId: string): boolean {
+	const owner = getWebhookSecretByPath(path);
+	return owner !== undefined && owner.routine_id !== routineId;
 }
 
 export function touchWebhookSecret(routineId: string): void {

--- a/apps/server/src/routes-routines.ts
+++ b/apps/server/src/routes-routines.ts
@@ -25,6 +25,8 @@ import {
 	updateV1Routine,
 } from "./db/routines.ts";
 import {
+	deleteWebhookSecret,
+	ensureWebhookSecret,
 	listStepRuns,
 	upsertWebhookSecret,
 } from "./db/routine-step-runs.ts";
@@ -209,7 +211,8 @@ export function buildRoutinesRouter(runner: RoutinesRunner): Hono {
 		}
 		const secret = randomBytes(32).toString("base64url");
 		const hash = hashSecretForStorage(secret);
-		upsertWebhookSecret({ routineId: id, path: webhookTrigger.webhook.path, secretHash: hash });
+		const registered = upsertWebhookSecret({ routineId: id, path: webhookTrigger.webhook.path, secretHash: hash });
+		if (!registered) return c.json({ error: "webhook path already in use" }, 409);
 		return c.json({ ok: true, secret, path: webhookTrigger.webhook.path });
 	});
 
@@ -295,24 +298,22 @@ export function buildRoutinesRouter(runner: RoutinesRunner): Hono {
 }
 
 function registerWebhookTriggers(spec: RoutineSpec, routineId: string): void {
-	// If any webhook trigger is declared, generate an initial secret. The caller
-	// retrieves it via /webhook-secret/rotate (which always returns the plain
-	// secret — same endpoint serves both initial issuance and rotation).
-	// V1 limitation: webhook paths are globally unique. If a path is already
-	// claimed by another routine, silently skip; the routine is still created
-	// without that webhook trigger active. V1.5 will surface this in the UI.
-	for (const t of spec.trigger) {
-		if ("webhook" in t) {
-			const secret = randomBytes(32).toString("base64url");
-			try {
-				upsertWebhookSecret({
-					routineId,
-					path: t.webhook.path,
-					secretHash: hashSecretForStorage(secret),
-				});
-			} catch (err) {
-				log.warn(`webhook path ${t.webhook.path} already in use; skipping registration for ${routineId}`, err);
-			}
-		}
+	// Keep the registration table in sync with the authored spec. Registering a
+	// trigger should be idempotent on save; only the explicit rotate endpoint
+	// replaces the stored secret hash.
+	const webhookTrigger = spec.trigger.find((t) => "webhook" in t) as { webhook: { path: string } } | undefined;
+	if (!webhookTrigger) {
+		deleteWebhookSecret(routineId);
+		return;
+	}
+
+	const secret = randomBytes(32).toString("base64url");
+	const registered = ensureWebhookSecret({
+		routineId,
+		path: webhookTrigger.webhook.path,
+		secretHash: hashSecretForStorage(secret),
+	});
+	if (!registered) {
+		log.warn(`webhook path ${webhookTrigger.webhook.path} already in use; skipping registration for ${routineId}`);
 	}
 }

--- a/apps/web/src/components/routines/RoutineBuilder.tsx
+++ b/apps/web/src/components/routines/RoutineBuilder.tsx
@@ -9,14 +9,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Copy, RefreshCcw } from "lucide-react";
 
-import type {
-	Routine,
-	RoutineDeckAction,
-	RoutineRun,
-	RoutineSpec,
-	RoutineStep,
-	RoutineTrigger,
-	ValidationError,
+import {
+	validateRoutineSpec,
+	type Routine,
+	type RoutineDeckAction,
+	type RoutineRun,
+	type RoutineSpec,
+	type RoutineStep,
+	type RoutineTrigger,
+	type ValidationError,
 } from "@omp-deck/protocol";
 
 import { routinesApi } from "@/lib/routines-api";
@@ -30,6 +31,17 @@ import { AddStepPicker } from "./AddStepPicker";
 import { SettingsForm } from "./SettingsForm";
 import { StepCard } from "./StepCard";
 import { TriggerPicker } from "./TriggerPicker";
+import {
+	appendStepRenderKey,
+	makeStepRenderKeys,
+	moveStepRenderKey,
+	reconcileStepRenderKeys,
+	removeStepRenderKey,
+} from "./step-render-keys";
+import {
+	type RoutineValidationMessage,
+	summarizeRoutineValidationErrors,
+} from "./routine-validation";
 import {
 	emptyV1Spec,
 	insertStep,
@@ -71,7 +83,21 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 		return emptyV1Spec();
 	}, [routine]);
 
+	const stepKeySeq = useRef(0);
+	function nextStepKey(): string {
+		const n = stepKeySeq.current;
+		stepKeySeq.current += 1;
+		return `step-${n}`;
+	}
+	function makeStepKeys(count: number): string[] {
+		return makeStepRenderKeys(count, nextStepKey);
+	}
+	function reconcileStepKeys(next: RoutineSpec): void {
+		setStepKeys((prev) => reconcileStepRenderKeys(prev, next.steps.length, nextStepKey));
+	}
+
 	const [spec, setSpec] = useState<RoutineSpec>(initialSpec);
+	const [stepKeys, setStepKeys] = useState<string[]>(() => makeStepKeys(initialSpec.steps.length));
 	const [yamlBuffer, setYamlBuffer] = useState<string>(() =>
 		routine?.specYaml ?? stringifySpec(initialSpec),
 	);
@@ -97,6 +123,7 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 	useEffect(() => {
 		if (lastRoutineId.current === routine?.id) return;
 		lastRoutineId.current = routine?.id;
+		setStepKeys(makeStepKeys(initialSpec.steps.length));
 		setSpec(initialSpec);
 		setYamlBuffer(routine?.specYaml ?? stringifySpec(initialSpec));
 		setYamlDirty(false);
@@ -111,8 +138,12 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 		void routinesApi.runs(routine.id, 10).then((r) => setRuns(r.runs));
 	}, [routine]);
 
-	// Form -> YAML sync.
-	function updateSpec(next: RoutineSpec): void {
+	// Form -> YAML sync. Step cards use render-only keys that are deliberately
+	// separate from editable step ids; otherwise changing `id` remounts the
+	// active input and drops focus after every character.
+	function updateSpec(next: RoutineSpec, nextStepKeys?: string[]): void {
+		if (nextStepKeys) setStepKeys(nextStepKeys);
+		else reconcileStepKeys(next);
 		setSpec(next);
 		setYamlBuffer(stringifySpec(next));
 		setYamlDirty(false);
@@ -130,7 +161,9 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 			else setSchemaErrors(undefined);
 			return false;
 		}
-		setSpec(result.spec ?? emptyV1Spec());
+		const nextSpec = result.spec ?? emptyV1Spec();
+		setStepKeys(makeStepKeys(nextSpec.steps.length));
+		setSpec(nextSpec);
 		setYamlDirty(false);
 		setYamlError(undefined);
 		setSchemaErrors(undefined);
@@ -147,6 +180,11 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 		setTab(next);
 	}
 
+	const specValidation = useMemo(() => validateRoutineSpec(spec), [spec]);
+	const specValidationMessages = useMemo(
+		() => summarizeRoutineValidationErrors(specValidation.errors, spec),
+		[specValidation.errors, spec],
+	);
 	// Compile the canvas graph on every spec change. In the linear short-circuit
 	// path (no `layout.edges`), this is the identity function; it only does work
 	// when the user has wired explicit edges via the canvas. Errors gate Save
@@ -167,6 +205,11 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 				return;
 			}
 		}
+		if (!specValidation.valid) {
+			onError(`Cannot save: ${specValidationMessages[0]?.message ?? "Spec is invalid"}`);
+			return;
+		}
+
 		// Re-compile against the freshest spec (applyYaml may have mutated it
 		// since the memo snapshotted). Block save when any error is present;
 		// the canvas error strip already shows the user what is broken.
@@ -258,22 +301,27 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 
 	const existingStepIds = spec.steps.map((s) => s.id);
 	function onAddStep(type: RoutineStep["type"], presetAction?: RoutineDeckAction): void {
-		updateSpec(insertStep(spec, scaffoldStep(type, existingStepIds, presetAction)));
+		updateSpec(
+			insertStep(spec, scaffoldStep(type, existingStepIds, presetAction)),
+			appendStepRenderKey(stepKeys, nextStepKey),
+		);
 	}
 	function onChangeStep(index: number, next: RoutineStep): void {
-		updateSpec(replaceStep(spec, index, next));
+		updateSpec(replaceStep(spec, index, next), stepKeys);
 	}
 	function onRemoveStep(index: number): void {
-		updateSpec(removeStep(spec, index));
+		updateSpec(removeStep(spec, index), removeStepRenderKey(stepKeys, index));
 	}
 	function onMoveUp(index: number): void {
-		updateSpec(moveStep(spec, index, Math.max(0, index - 1)));
+		const target = Math.max(0, index - 1);
+		updateSpec(moveStep(spec, index, target), moveStepRenderKey(stepKeys, index, target));
 	}
 	function onMoveDown(index: number): void {
-		updateSpec(moveStep(spec, index, Math.min(spec.steps.length - 1, index + 1)));
+		const target = Math.min(spec.steps.length - 1, index + 1);
+		updateSpec(moveStep(spec, index, target), moveStepRenderKey(stepKeys, index, target));
 	}
 	function onChangeTriggers(triggers: RoutineTrigger[]): void {
-		updateSpec(replaceTriggers(spec, triggers));
+		updateSpec(replaceTriggers(spec, triggers), stepKeys);
 	}
 
 	// ─── Render ────────────────────────────────────────────────────────────
@@ -282,6 +330,7 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 		spec.name.trim().length > 0 &&
 		spec.trigger.length > 0 &&
 		spec.steps.length > 0 &&
+		specValidation.valid &&
 		compile.errors.length === 0 &&
 		!busy;
 
@@ -312,7 +361,7 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 						) : (
 							spec.steps.map((step, idx) => (
 								<StepCard
-									key={`${step.id}-${idx}`}
+									key={`${routine?.id ?? "new"}-${stepKeys[idx] ?? idx}`}
 									step={step}
 									index={idx}
 									total={spec.steps.length}
@@ -445,6 +494,9 @@ export function RoutineBuilder({ routine, onSaved, onError }: Props) {
 					</div>
 				) : null}
 			</div>
+			{specValidationMessages.length > 0 ? (
+				<ValidationSummary messages={specValidationMessages} />
+			) : null}
 			<Footer
 				routine={routine}
 				canSave={canSave}
@@ -514,6 +566,18 @@ function TabBar({
 		</div>
 	);
 }
+function ValidationSummary({ messages }: { messages: readonly RoutineValidationMessage[] }) {
+	return (
+		<div className="border-t border-danger/30 bg-danger/5 px-3 py-2">
+			<div className="meta mb-1 text-danger">Fix before saving</div>
+			<ul className="space-y-0.5 font-mono text-2xs text-danger">
+				{messages.slice(0, 4).map((message) => (
+					<li key={`${message.path}:${message.message}`}>{message.message}</li>
+				))}
+			</ul>
+		</div>
+	);
+}
 
 function Footer({
 	routine,
@@ -540,7 +604,7 @@ function Footer({
 			</label>
 			<div className="ml-auto flex items-center gap-1.5">
 				{routine ? (
-					<button type="button" onClick={onRunNow} className="btn-ghost text-2xs">
+					<button type="button" onClick={onRunNow} className="btn-ghost h-7 px-2 text-2xs">
 						Run now
 					</button>
 				) : null}
@@ -548,7 +612,7 @@ function Footer({
 					type="button"
 					onClick={onSave}
 					disabled={!canSave}
-					className="btn-primary text-2xs disabled:opacity-50"
+					className="btn-primary h-7 px-2 text-2xs disabled:opacity-50"
 				>
 					{busy ? "Saving..." : routine ? "Save" : "Create"}
 				</button>

--- a/apps/web/src/components/routines/RoutineEditor.tsx
+++ b/apps/web/src/components/routines/RoutineEditor.tsx
@@ -447,7 +447,7 @@ function V0Editor({
 						<button
 							type="button"
 							onClick={() => void runNow()}
-							className="btn-ghost text-xs"
+							className="btn-ghost h-7 px-2.5 text-xs"
 							title="Run now (out of schedule)"
 						>
 							Run now
@@ -457,7 +457,7 @@ function V0Editor({
 						type="button"
 						onClick={() => void save()}
 						disabled={busy || !form.name.trim() || !form.cron.trim() || !form.actionBody.trim()}
-						className="btn-primary text-xs"
+						className="btn-primary h-7 px-2.5 text-xs"
 					>
 						{isNew ? "Create" : "Save"}
 					</button>

--- a/apps/web/src/components/routines/StepCommonFields.tsx
+++ b/apps/web/src/components/routines/StepCommonFields.tsx
@@ -1,6 +1,7 @@
 import type { RoutineOnFailure, RoutineRetryPolicy, RoutineStep } from "@omp-deck/protocol";
 
 import { Field, NumInput, TextInput } from "./form-primitives";
+import { validateStepId } from "./routine-validation";
 
 interface Props {
 	step: RoutineStep;
@@ -23,12 +24,14 @@ export function StepCommonFields({ step, onChange, existingIds }: Props) {
 		onChange(next);
 	}
 	const idCollision = existingIds.includes(step.id);
+	const idError = validateStepId(step.id);
+	const idHint = idCollision ? "duplicate" : idError;
 	const retry = step.retry;
 
 	return (
 		<div className="space-y-2 rounded border border-line bg-paper-2/40 p-2">
 			<div className="grid grid-cols-2 gap-2">
-				<Field label="id" hint={idCollision ? "duplicate" : undefined} tone={idCollision ? "danger" : undefined}>
+				<Field label="id" hint={idHint} tone={idHint ? "danger" : undefined}>
 					<TextInput value={step.id} onChange={(v) => set("id", v)} placeholder="fetch_tasks" mono />
 				</Field>
 				<Field label="on_failure">

--- a/apps/web/src/components/routines/routine-validation.test.ts
+++ b/apps/web/src/components/routines/routine-validation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import type { RoutineSpec, ValidationError } from "@omp-deck/protocol";
+
+import { summarizeRoutineValidationErrors, validateStepId } from "./routine-validation";
+
+const spec: RoutineSpec = {
+	name: "daily-briefing",
+	trigger: [{ manual: {} }],
+	steps: [
+		{ id: "should_run", type: "transform", body: "return true" },
+		{ id: "Agent Bad", type: "agent", prompt: "hello" },
+	],
+};
+
+describe("routine validation summaries", () => {
+	test("validates step ids with the same pattern as the schema", () => {
+		expect(validateStepId("agent_1")).toBeUndefined();
+		expect(validateStepId("Agent Bad")).toContain("lowercase");
+		expect(validateStepId("1_agent")).toContain("start with a letter");
+	});
+
+	test("collapses Ajv oneOf noise to the relevant invalid id", () => {
+		const errors: ValidationError[] = [
+			{
+				path: "/steps/1/id",
+				keyword: "pattern",
+				message: 'must match pattern "^[a-z][a-z0-9_]*$"',
+				params: { pattern: "^[a-z][a-z0-9_]*$" },
+			},
+			{
+				path: "/steps/1",
+				keyword: "required",
+				message: "must have required property 'command'",
+				params: { missingProperty: "command" },
+			},
+			{
+				path: "/steps/1/type",
+				keyword: "const",
+				message: "must be equal to constant",
+				params: { allowedValue: "run" },
+			},
+			{
+				path: "/steps/1",
+				keyword: "oneOf",
+				message: "must match exactly one schema in oneOf",
+				params: { passingSchemas: null },
+			},
+		];
+
+		expect(summarizeRoutineValidationErrors(errors, spec)).toEqual([
+			{
+				path: "/steps/1/id",
+				message: "Step 2 (agent) id: use lowercase letters, numbers, and underscores; start with a letter",
+			},
+		]);
+	});
+});

--- a/apps/web/src/components/routines/routine-validation.ts
+++ b/apps/web/src/components/routines/routine-validation.ts
@@ -1,0 +1,76 @@
+import type { RoutineSpec, RoutineStep, ValidationError } from "@omp-deck/protocol";
+
+export const STEP_ID_PATTERN = /^[a-z][a-z0-9_]*$/;
+export const STEP_ID_REQUIREMENT = "use lowercase letters, numbers, and underscores; start with a letter";
+
+export function validateStepId(id: string): string | undefined {
+	if (id.length === 0) return "required";
+	return STEP_ID_PATTERN.test(id) ? undefined : STEP_ID_REQUIREMENT;
+}
+
+export interface RoutineValidationMessage {
+	path: string;
+	message: string;
+}
+
+const REQUIRED_BY_TYPE: Record<RoutineStep["type"], readonly string[]> = {
+	run: ["id", "type", "command"],
+	agent: ["id", "type", "prompt"],
+	write: ["id", "type", "path", "content"],
+	http: ["id", "type", "method", "url"],
+	deck: ["id", "type", "action"],
+	mcp: ["id", "type", "server", "tool"],
+	transform: ["id", "type", "body"],
+	wait: ["id", "type", "duration_secs"],
+	set_state: ["id", "type", "state"],
+};
+
+export function summarizeRoutineValidationErrors(
+	errors: readonly ValidationError[] | undefined,
+	spec: RoutineSpec,
+): RoutineValidationMessage[] {
+	if (!errors || errors.length === 0) return [];
+
+	const messages: RoutineValidationMessage[] = [];
+	const seen = new Set<string>();
+	for (const error of errors) {
+		const message = summarizeValidationError(error, spec);
+		if (!message) continue;
+		const key = `${message.path}\u0000${message.message}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		messages.push(message);
+	}
+
+	return messages.length > 0 ? messages : [{ path: "/", message: "Spec is invalid" }];
+}
+
+function summarizeValidationError(error: ValidationError, spec: RoutineSpec): RoutineValidationMessage | undefined {
+	if (error.keyword === "oneOf") return undefined;
+
+	const stepMatch = /^\/steps\/(\d+)(?:\/([^/]+))?$/.exec(error.path);
+	if (stepMatch) {
+		const stepIndex = Number(stepMatch[1]);
+		const field = stepMatch[2];
+		const step = spec.steps[stepIndex];
+		const label = `Step ${stepIndex + 1}${step?.type ? ` (${step.type})` : ""}`;
+
+		if (field === "id" && error.keyword === "pattern") {
+			return { path: error.path, message: `${label} id: ${STEP_ID_REQUIREMENT}` };
+		}
+		if (field === "type" && error.keyword === "const" && step?.type) {
+			return undefined;
+		}
+		if (error.keyword === "required") {
+			const missing = typeof error.params.missingProperty === "string"
+				? error.params.missingProperty
+				: undefined;
+			if (!missing) return { path: error.path, message: `${label}: ${error.message}` };
+			if (step?.type && !REQUIRED_BY_TYPE[step.type].includes(missing)) return undefined;
+			return { path: error.path, message: `${label}: missing ${missing}` };
+		}
+		return { path: error.path, message: `${label}${field ? ` ${field}` : ""}: ${error.message}` };
+	}
+
+	return { path: error.path || "/", message: `${error.path || "/"}: ${error.message}` };
+}

--- a/apps/web/src/components/routines/step-render-keys.test.ts
+++ b/apps/web/src/components/routines/step-render-keys.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+	appendStepRenderKey,
+	makeStepRenderKeys,
+	moveStepRenderKey,
+	reconcileStepRenderKeys,
+	removeStepRenderKey,
+} from "./step-render-keys";
+
+function factory(): () => string {
+	let n = 0;
+	return () => `k${n++}`;
+}
+
+describe("routine step render keys", () => {
+	test("preserves keys when editable step ids change without changing list length", () => {
+		const create = factory();
+		const initial = makeStepRenderKeys(3, create);
+
+		expect(reconcileStepRenderKeys(initial, 3, create)).toEqual(initial);
+	});
+
+	test("appends and removes keys at the same positions as step edits", () => {
+		const create = factory();
+		const initial = makeStepRenderKeys(2, create);
+
+		expect(appendStepRenderKey(initial, create)).toEqual(["k0", "k1", "k2"]);
+		expect(removeStepRenderKey(["k0", "k1", "k2"], 1)).toEqual(["k0", "k2"]);
+	});
+
+	test("moves keys with their step so local card state does not stick to positions", () => {
+		expect(moveStepRenderKey(["first", "second", "third"], 2, 0)).toEqual([
+			"third",
+			"first",
+			"second",
+		]);
+	});
+});

--- a/apps/web/src/components/routines/step-render-keys.ts
+++ b/apps/web/src/components/routines/step-render-keys.ts
@@ -1,0 +1,34 @@
+export type StepRenderKeyFactory = () => string;
+
+export function makeStepRenderKeys(count: number, create: StepRenderKeyFactory): string[] {
+	return reconcileStepRenderKeys([], count, create);
+}
+
+export function reconcileStepRenderKeys(
+	previous: readonly string[],
+	nextCount: number,
+	create: StepRenderKeyFactory,
+): string[] {
+	const next = previous.slice(0, nextCount);
+	while (next.length < nextCount) next.push(create());
+	return next;
+}
+
+export function appendStepRenderKey(previous: readonly string[], create: StepRenderKeyFactory): string[] {
+	return [...previous, create()];
+}
+
+export function removeStepRenderKey(previous: readonly string[], index: number): string[] {
+	return previous.filter((_key, i) => i !== index);
+}
+
+export function moveStepRenderKey(previous: readonly string[], from: number, to: number): string[] {
+	if (from === to || from < 0 || to < 0 || from >= previous.length || to >= previous.length) {
+		return previous.slice();
+	}
+	const next = previous.slice();
+	const [key] = next.splice(from, 1);
+	if (!key) return previous.slice();
+	next.splice(to, 0, key);
+	return next;
+}


### PR DESCRIPTION
## Summary

This PR fixes the routine editing/save path end to end: step ID fields can be edited continuously without losing focus, invalid specs are blocked with actionable client-side validation before they hit the server, webhook trigger registration is safe to save repeatedly, and the routine editor action buttons now have consistent spacing.

## What changed

### Stable step ID editing

- Decoupled React render keys for step cards from editable `step.id` values.
- Added render-key helpers so add/remove/move operations preserve each card's local state without tying component identity to the user-editable ID.
- Covered the key behavior with regression tests so renaming a step no longer remounts the active input after every character.
**Note: this was an annoying but where each character typed would unfocus the input and require the user clicking back on the input to type the next character**

### Client-side routine validation before save

- Reused the shared routine spec validator in the web builder before enabling Save.
- Added focused validation messaging for invalid step IDs, e.g. lowercase/underscore requirements, instead of exposing the raw Ajv `oneOf` cascade.
- Added inline ID field hints so users can fix invalid IDs before attempting a save.
**Note: I was using dashes instead of underscore and received a backend error that polluted my screen so now there is client-side validation. This can probably be a more broad exercise to add more client-side validation so that the UI catches bad inputs before server-side issues. Solved it for this use case.**

### Idempotent webhook registration

- Changed webhook secret upsert to detect path ownership conflicts instead of throwing `SQLITE_CONSTRAINT_UNIQUE` for `routine_webhook_secrets.path`.
- Added an `ensureWebhookSecret` path for routine saves so saving a webhook routine is idempotent and does not rotate the existing secret.
- Keeps registrations in sync when a routine webhook path changes, removes stale registrations when a webhook trigger is deleted, and returns a clear `409` when explicit secret rotation conflicts with another routine's path.
- Added DB regression coverage for duplicate path handling, idempotent saves, path moves, and stale registration deletion.
**Note: saving an update to the routine would throw a webhook error for a unique constraint. This solution keeps the upsert clean and idempotent.**

### Button spacing polish

- Normalized the V0 routine editor Run now and Save/Create buttons with explicit height and horizontal padding so they align visually with the newer routine builder controls.
**Note: They were too little :)**

## Verification

- `bun test apps/web/src/components/routines`
- `bun test apps/server/src/db/routine-step-runs.test.ts`
- `bun run --filter='@omp-deck/*' typecheck`
- `bun run --filter '@omp-deck/web' build`
- Browser smoke against `http://127.0.0.1:5173/routines?edit=r_01kst1dn66nrg8kj6z`:
  - typed continuously in a routine step ID field and confirmed focus stayed in the input
  - entered an invalid step ID and confirmed Save disabled with focused client-side validation
  - restored a valid ID and confirmed Save re-enabled
  - saved the routine successfully and observed the PATCH return HTTP 200

## Screenshots
<img width="1049" height="543" alt="image" src="https://github.com/user-attachments/assets/1adc2f1d-4707-45f2-aa56-d65b6f896d20" />
