### PR TITLE
fix(models, oauth): placeholder-key suppression, subscription badge, 401 hint, OAuth flow timeout

### DIFF
--- a/apps/server/src/bridge/in-process.ts
+++ b/apps/server/src/bridge/in-process.ts
@@ -5,6 +5,7 @@ import {
 	settings as ompSettings,
 	type AgentSession,
 } from "@oh-my-pi/pi-coding-agent";
+import { getEnvApiKey, getOAuthProviders } from "@oh-my-pi/pi-ai";
 import { runExtensionCompact, runExtensionSetModel } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/get-commands-handler";
 // `Model` is owned by `@oh-my-pi/pi-ai`, a transitive dep we don't bring in
@@ -33,7 +34,9 @@ import type {
 
 import { logger } from "../log.ts";
 import { getDeckModelRegistry } from "../auth-singleton.ts";
+import { looksLikePlaceholderKey } from "../credential-quality.ts";
 import { getEffectivePrelude } from "../orientation-store.ts";
+import { notificationService } from "../notifications/index.ts";
 import { ExtensionUIBridge } from "./ext-ui-bridge.ts";
 import { PlanModeBridge } from "./plan-mode-bridge.ts";
 import type {
@@ -458,6 +461,21 @@ export class InProcessAgentBridge implements AgentBridge {
 					}
 				}
 			}
+			// Issue #4 recovery hint: when the SDK surfaces an auth-shaped error
+			// (401 / "Incorrect API key") on a request to an API-key provider
+			// AND a subscription (OAuth) variant of the same model name exists
+			// AND is actually authenticated, fire a deck notification telling
+			// the operator to switch. Without this, the chat shows the raw 401
+			// inline and the operator has no idea why a fresh ChatGPT-Plus
+			// install rejected their first prompt. See issue #4.
+			if (type === "notice") {
+				const n = event as { level?: string; message?: string };
+				if (n.level === "error" && typeof n.message === "string" && looksLikeAuthError(n.message)) {
+					this.maybeSuggestSubscriptionFallback(session, n.message).catch((err) =>
+						log.warn("subscription-fallback hint failed", err),
+					);
+				}
+			}
 		});
 
 		this.active.set(sessionId, {
@@ -536,6 +554,46 @@ export class InProcessAgentBridge implements AgentBridge {
 		if (!entry) return "unknown";
 		this.bumpActivity(sessionId);
 		return entry.planBridge.respond(proposalId, response);
+	}
+
+	/**
+	 * Issue #4: emit a deck notification when an inline auth error on the
+	 * current model has a known recovery path (subscription provider with
+	 * the same model id is authenticated). Idempotent in the failure case —
+	 * if any precondition is missing we just bail silently. The notification
+	 * lands in the standard dropdown + optional OS toast so the operator
+	 * sees it even if the chat is scrolled past the inline error.
+	 */
+	private async maybeSuggestSubscriptionFallback(
+		session: AgentSession,
+		errorMessage: string,
+	): Promise<void> {
+		const snap = (session as unknown as { snapshot?: () => { model?: { provider?: string; id?: string } } }).snapshot?.();
+		const current = snap?.model;
+		if (!current?.provider || !current.id) return;
+		// Already on a subscription provider — nothing to suggest.
+		if (getSubscriptionProviders().has(current.provider)) return;
+		const registry = await this.ensureModelRegistry();
+		// Look for any subscription provider carrying the same model id that's
+		// authenticated (auth.db has OAuth credential).
+		const alternative = registry
+			.getAll()
+			.map((m) => m as unknown as SdkModel)
+			.find((m) => {
+				if (m.id !== current.id) return false;
+				const provider = String(m.provider);
+				if (!getSubscriptionProviders().has(provider)) return false;
+				const sdkModel = m as unknown as Parameters<ModelRegistry["isUsingOAuth"]>[0];
+				return registry.isUsingOAuth(sdkModel);
+			});
+		if (!alternative) return;
+		const altProvider = String(alternative.provider);
+		await notificationService.notify({
+			level: "warn",
+			title: `Authentication failed for ${current.provider}/${current.id}`,
+			body: `You appear to be authenticated for the same model under \`${altProvider}\` (subscription). Switch in the model picker to use your subscription instead.\n\nOriginal error: ${errorMessage.slice(0, 240)}`,
+			source: `bridge:auth-fallback`,
+		});
 	}
 }
 
@@ -1108,17 +1166,79 @@ function summarize(raw: any): SessionSummary {
 	};
 }
 
+/**
+ * Set of provider IDs that expose a browser-OAuth (subscription) flow,
+ * derived once from the SDK's `getOAuthProviders()`. Memoized: the SDK's
+ * list is static per process and we'd otherwise rebuild it on every model
+ * row. Used for two purposes by `modelInfoFromSdk`:
+ *   - Tag rows with `isSubscription: true` so the picker can badge them.
+ *   - Skip placeholder-key suppression — OAuth credentials live in
+ *     `auth.db` and may legitimately have a related env var unset or set
+ *     to something the API-key heuristics don't recognize as real.
+ */
+let subscriptionProvidersCache: Set<string> | undefined;
+function getSubscriptionProviders(): Set<string> {
+	if (!subscriptionProvidersCache) {
+		subscriptionProvidersCache = new Set(getOAuthProviders().map((p) => p.id));
+	}
+	return subscriptionProvidersCache;
+}
+
+/**
+ * Heuristic match for "this error is an auth failure on the API call we
+ * just made". Used to gate the issue-#4 subscription-fallback hint. Kept
+ * narrow on purpose: false positives mean we suggest a switch when none is
+ * needed, which is annoying; the worst case is silence on a less-common
+ * error shape, which is the existing behavior.
+ */
+function looksLikeAuthError(message: string): boolean {
+	const m = message.toLowerCase();
+	if (m.includes("401")) return true;
+	if (m.includes("incorrect api key")) return true;
+	if (m.includes("invalid api key")) return true;
+	if (m.includes("invalid_api_key")) return true;
+	if (m.includes("unauthorized")) return true;
+	if (m.includes("authentication failed")) return true;
+	if (m.includes("api key is required")) return true;
+	return false;
+}
+
 function modelInfoFromSdk(
 	model: SdkModel,
 	registry: ModelRegistry,
 	current: { provider: string; id: string } | undefined,
 ): ModelInfo {
+	const provider = String(model.provider);
+	const sdkModel = model as unknown as Parameters<ModelRegistry["hasConfiguredAuth"]>[0];
+	const hasAuth = registry.hasConfiguredAuth(sdkModel);
+	const usingOAuth = registry.isUsingOAuth(sdkModel);
+	const isSubscription = getSubscriptionProviders().has(provider);
+	// `isAvailable` semantics: would a call routed to this provider succeed?
+	//   - SDK reports no configured auth at all → false (keyless paths are
+	//     also flagged via hasConfiguredAuth, so this also covers them).
+	//   - SDK has an OAuth credential in auth.db (`isUsingOAuth`) → true,
+	//     regardless of what's in process.env.
+	//   - Otherwise an env-var API key is the credential source. Validate
+	//     that the value isn't a known placeholder (`sk-your-…here`, etc.)
+	//     — see credential-quality.ts and issue #4.
+	let isAvailable = hasAuth;
+	if (isAvailable && !usingOAuth) {
+		const envValue = getEnvApiKey(provider);
+		// Only suppress when the env-var IS the credential. An empty env var
+		// with `hasConfiguredAuth=true` means auth came from somewhere else
+		// (auth.db non-OAuth entry, keyless provider, foundry, etc.) — trust
+		// the SDK in that case.
+		if (envValue && looksLikePlaceholderKey(envValue)) {
+			isAvailable = false;
+		}
+	}
 	const info: ModelInfo = {
-		provider: String(model.provider),
+		provider,
 		id: model.id,
 		label: model.name || model.id,
-		isAvailable: registry.hasConfiguredAuth(model as unknown as Parameters<ModelRegistry["hasConfiguredAuth"]>[0]),
+		isAvailable,
 	};
+	if (isSubscription) info.isSubscription = true;
 	if (typeof model.contextWindow === "number" && model.contextWindow > 0) {
 		info.contextWindow = model.contextWindow;
 	}

--- a/apps/server/src/bridge/in-process.ts
+++ b/apps/server/src/bridge/in-process.ts
@@ -5,7 +5,7 @@ import {
 	settings as ompSettings,
 	type AgentSession,
 } from "@oh-my-pi/pi-coding-agent";
-import { getEnvApiKey, getOAuthProviders } from "@oh-my-pi/pi-ai";
+import { getEnvApiKey } from "@oh-my-pi/pi-ai";
 import { runExtensionCompact, runExtensionSetModel } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/compact-handler";
 import { getSessionSlashCommands } from "@oh-my-pi/pi-coding-agent/extensibility/extensions/get-commands-handler";
 // `Model` is owned by `@oh-my-pi/pi-ai`, a transitive dep we don't bring in
@@ -1167,21 +1167,44 @@ function summarize(raw: any): SessionSummary {
 }
 
 /**
- * Set of provider IDs that expose a browser-OAuth (subscription) flow,
- * derived once from the SDK's `getOAuthProviders()`. Memoized: the SDK's
- * list is static per process and we'd otherwise rebuild it on every model
- * row. Used for two purposes by `modelInfoFromSdk`:
+ * Provider IDs that represent a true consumer subscription — the user
+ * paid a monthly fee (Claude Pro/Max, ChatGPT Plus/Pro, Copilot, Cursor)
+ * or a coding plan (Z.AI GLM, Alibaba, MiniMax, Kimi). The picker badges
+ * these so users can tell subscription variants apart from API-key
+ * variants of the same model name (the actual bug from issue #4).
+ *
+ * Intentionally an explicit allowlist, not `getOAuthProviders()` from the
+ * SDK. The SDK's "OAuth providers" is a broader category that also
+ * includes local runtimes (Ollama, LM Studio, vLLM), gateway services
+ * (LiteLLM, Kilo, Cloudflare AI Gateway), and pure-API-tier providers
+ * (Cerebras, Fireworks, Together, HuggingFace) — none of which are
+ * "subscriptions" in the user-facing sense. Calling Ollama a
+ * "subscription" in the model picker is actively misleading.
+ *
+ * Used for two purposes by `modelInfoFromSdk` and the issue-#4 hint:
  *   - Tag rows with `isSubscription: true` so the picker can badge them.
- *   - Skip placeholder-key suppression — OAuth credentials live in
- *     `auth.db` and may legitimately have a related env var unset or set
- *     to something the API-key heuristics don't recognize as real.
+ *   - Pick recovery targets for the 401-fallback notification.
+ *
+ * When the SDK adds a new subscription-style provider, add it here.
+ * False negatives (missing a real subscription) are graceful — the user
+ * just doesn't get the badge. False positives (claiming Ollama is a
+ * subscription) are confusing and that's what we're fixing here.
  */
-let subscriptionProvidersCache: Set<string> | undefined;
-function getSubscriptionProviders(): Set<string> {
-	if (!subscriptionProvidersCache) {
-		subscriptionProvidersCache = new Set(getOAuthProviders().map((p) => p.id));
-	}
-	return subscriptionProvidersCache;
+const SUBSCRIPTION_PROVIDER_IDS: ReadonlySet<string> = new Set([
+	"anthropic", // Claude Pro/Max — competes with anthropic API key for Claude models
+	"openai-codex", // ChatGPT Plus/Pro — competes with openai API key for gpt-5/etc.
+	"github-copilot", // Copilot subscription
+	"cursor", // Cursor IDE subscription — surfaces Claude/GPT models
+	"perplexity", // Perplexity Pro/Max — competes with perplexity API key
+	"alibaba-coding-plan", // Alibaba Coding Plan
+	"zai", // Z.AI GLM Coding Plan
+	"minimax-code", // MiniMax Coding Plan (International)
+	"minimax-code-cn", // MiniMax Coding Plan (China)
+	"kimi-code", // Kimi Code
+	"google-antigravity", // Google Antigravity (preview)
+]);
+function getSubscriptionProviders(): ReadonlySet<string> {
+	return SUBSCRIPTION_PROVIDER_IDS;
 }
 
 /**

--- a/apps/server/src/credential-quality.test.ts
+++ b/apps/server/src/credential-quality.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { looksLikePlaceholderKey } from "./credential-quality.ts";
+
+describe("looksLikePlaceholderKey", () => {
+	test("treats undefined / null / empty as placeholder", () => {
+		expect(looksLikePlaceholderKey(undefined)).toBe(true);
+		expect(looksLikePlaceholderKey(null)).toBe(true);
+		expect(looksLikePlaceholderKey("")).toBe(true);
+		expect(looksLikePlaceholderKey("   ")).toBe(true);
+		expect(looksLikePlaceholderKey("\n\t")).toBe(true);
+	});
+
+	test("rejects the exact value from issue #4", () => {
+		// The literal string OpenAI echoed back in the 401 from the bug report.
+		expect(looksLikePlaceholderKey("sk-your-XXXXXXXXXXXXXXXXhere")).toBe(true);
+		expect(looksLikePlaceholderKey("sk-your-api-key-here")).toBe(true);
+	});
+
+	test("rejects common .env.example placeholders", () => {
+		const cases = [
+			"sk-XXXXXXXXXXXXXXXX",
+			"sk-XXX",
+			"your-api-key",
+			"your_api_key_here",
+			"YOUR-OPENAI-KEY",
+			"<your-anthropic-key>",
+			"<api-key>",
+			"changeme",
+			"change-me",
+			"change_me",
+			"CHANGEME",
+			"example",
+			"example-key",
+			"example_value",
+			"placeholder",
+			"placeholder-token",
+			"dummy",
+			"dummy-key",
+			"test-key",
+			"testkey",
+			"${OPENAI_API_KEY}",
+			"$OPENAI_API_KEY",
+			"xxx",
+			"XXXXXX",
+			"?????",
+			"00000000000000000000",
+		];
+		for (const c of cases) {
+			expect(looksLikePlaceholderKey(c)).toBe(true);
+		}
+	});
+
+	test("rejects keys that are too short to be real for their family", () => {
+		expect(looksLikePlaceholderKey("sk-short")).toBe(true); // OpenAI floor 40
+		expect(looksLikePlaceholderKey("sk-ant-short")).toBe(true); // Anthropic floor 40
+		expect(looksLikePlaceholderKey("AIza-short")).toBe(true); // Google floor 30
+		expect(looksLikePlaceholderKey("xai-short")).toBe(true); // xAI floor 40
+		expect(looksLikePlaceholderKey("gsk_short")).toBe(true); // Groq floor 40
+	});
+
+	test("accepts realistic-looking keys", () => {
+		// Realistic-shape values (random, not real). We accept anything that's
+		// the right shape and length for its prefix family.
+		expect(
+			looksLikePlaceholderKey(
+				"sk-proj-Ab9cD3fGh2jKl4mNo5pQr6sTu7vWx8yZ0a1bC2dE3fG4hI5jK6lM7nO8pQ9r",
+			),
+		).toBe(false);
+		expect(
+			looksLikePlaceholderKey(
+				"sk-ant-api03-aB1cD2eF3gH4iJ5kL6mN7oP8qR9sT0uV1wX2yZ3aB4cD5eF6gH7iJ8kL9mN0o-AbCdEf",
+			),
+		).toBe(false);
+		expect(looksLikePlaceholderKey("AIzaSyA1bC2dE3fG4hI5jK6lM7nO8pQ9rS0tUv")).toBe(false);
+		expect(
+			looksLikePlaceholderKey("gsk_AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIj"),
+		).toBe(false);
+		// Generic 32+ char hex token (no recognizable prefix)
+		expect(
+			looksLikePlaceholderKey("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+		).toBe(false);
+	});
+
+	test("accepts OAuth bearer tokens with the standard JWT-ish shape", () => {
+		// OAuth tokens stored in env (e.g. OPENAI_CODEX_OAUTH_TOKEN) are
+		// typically long base64-ish blobs. Make sure we don't false-positive.
+		expect(
+			looksLikePlaceholderKey(
+				"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4ifQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+			),
+		).toBe(false);
+	});
+});

--- a/apps/server/src/credential-quality.ts
+++ b/apps/server/src/credential-quality.ts
@@ -1,0 +1,83 @@
+/**
+ * Heuristics for detecting placeholder / invalid provider credential values.
+ *
+ * Motivating bug (issue #4): a user demoed the deck and a viewer clicked
+ * `gpt-5`, expecting their ChatGPT Plus subscription to drive the request.
+ * Instead OpenAI returned `401 Incorrect API key provided: sk-your-****here`.
+ * The literal placeholder `sk-your-...here` had been sitting in their
+ * environment (common .env.example value); the SDK saw a non-empty
+ * `OPENAI_API_KEY`, marked the openai-provider variant of `gpt-5` as
+ * available, and that beat the openai-codex (subscription) variant of the
+ * same model name in the picker.
+ *
+ * `looksLikePlaceholderKey` is what the deck's model-availability layer
+ * uses to suppress these false-positive credentials so the picker only
+ * surfaces models the user can actually call. It's intentionally
+ * conservative — we'd rather hide a few real-but-weird keys than ship a
+ * model that 401s on click.
+ */
+
+/**
+ * Patterns that match values commonly seen in tutorial `.env.example` files
+ * or "I'll fill this in later" stubs. Matched case-insensitively against the
+ * trimmed value.
+ */
+const PLACEHOLDER_PATTERNS: readonly RegExp[] = [
+	// `sk-your-XXXXhere`, `sk-your-api-key-here`, ...
+	/^sk-your[-_]/i,
+	// `sk-XXXXXX`, `sk-XXX...`
+	/^sk-x{3,}/i,
+	// `your-api-key`, `your_api_key_here`, `YOUR-OPENAI-KEY`, ...
+	/^your[-_ ]?(api|openai|anthropic|google|key)/i,
+	// `<your-key>`, `<api-key>`, ...
+	/^<.*>$/,
+	// `changeme`, `change-me`, `change_me`
+	/^change[-_ ]?me/i,
+	// `example`, `example-key`, `example_value`
+	/^example([-_ ]|$)/i,
+	// `placeholder`, `placeholder-key`, ...
+	/^placeholder/i,
+	// `dummy`, `dummy-key`, ...
+	/^dummy([-_ ]|$)/i,
+	// `test-key`, `testkey`, `test_key` — too short to be a real secret
+	/^test[-_]?key/i,
+	// Unsubstituted shell variable references: `${OPENAI_API_KEY}`, `$VAR`
+	/^\$\{/,
+	/^\$[A-Z_][A-Z0-9_]*$/,
+	// All-X or all-? values
+	/^x+$/i,
+	/^\?+$/,
+	// All-zero placeholder
+	/^0+$/,
+];
+
+/**
+ * Minimum length for a value that doesn't otherwise look like a placeholder,
+ * keyed by recognizable prefix. Real provider keys are well over these
+ * bounds; anything shorter is almost certainly a stub.
+ */
+function minimumReasonableLength(value: string): number {
+	if (value.startsWith("sk-ant-")) return 40; // Anthropic keys ~108 chars
+	if (value.startsWith("sk-or-")) return 40; // OpenRouter
+	if (value.startsWith("sk-")) return 40; // OpenAI ~51 chars
+	if (value.startsWith("AIza")) return 30; // Google API keys 39 chars
+	if (value.startsWith("xai-")) return 40; // xAI
+	if (value.startsWith("gsk_")) return 40; // Groq
+	return 16; // Generic floor — narrower would catch real values
+}
+
+/**
+ * Returns true when `value` is empty or matches a known placeholder pattern.
+ * Empty/whitespace counts as a placeholder because the caller treats `true`
+ * as "do not advertise this credential as usable."
+ */
+export function looksLikePlaceholderKey(value: string | undefined | null): boolean {
+	if (value === undefined || value === null) return true;
+	const v = value.trim();
+	if (v.length === 0) return true;
+	for (const re of PLACEHOLDER_PATTERNS) {
+		if (re.test(v)) return true;
+	}
+	if (v.length < minimumReasonableLength(v)) return true;
+	return false;
+}

--- a/apps/server/src/routes-auth-oauth.test.ts
+++ b/apps/server/src/routes-auth-oauth.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the OAuth-flow lifecycle behavior added to fix issue #5
+ * (stale flows blocking new attempts forever):
+ *
+ *   1. cancel cleans up promptResolvers too (latent bug — pre-fix the
+ *      cancel handler only rejected manualCode, leaving onPrompt deferreds
+ *      hanging).
+ *   2. abortFlow is idempotent — calling it on a torn-down flow is a no-op.
+ *
+ * The route handler itself is exercised at the integration level rather
+ * than unit-tested directly because it depends on the real SDK
+ * `auth.login()` — mocking that would be more test scaffolding than
+ * value. The cleanup helper is the load-bearing piece; that's what we
+ * cover here.
+ *
+ * The timeout-eviction path is verified by manual inspection rather than
+ * a timer-mocked unit test: the timer's body is one log line + a call to
+ * `abortFlow` + a `broadcastBus.broadcast`, which would all be re-mocked
+ * for unit coverage. The behavioral guarantee (flow disappears from the
+ * map after OAUTH_FLOW_MAX_MS) is straightforward to verify by hand.
+ */
+import { describe, expect, test } from "bun:test";
+
+// Re-export the helper as a private surface for tests. The route file
+// keeps it module-private; we duplicate the relevant invariants here.
+// This keeps the test focused on the contract without needing to spin
+// up Hono or the SDK.
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason?: unknown) => void;
+}
+function defer<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+interface MinimalFlow {
+	ac: AbortController;
+	consentReady: Deferred<unknown>;
+	manualCode: Deferred<string>;
+	promptResolvers: Map<string, (answer: string) => void>;
+	expirationTimer: ReturnType<typeof setTimeout>;
+}
+
+function makeFlow(): MinimalFlow {
+	const flow: MinimalFlow = {
+		ac: new AbortController(),
+		consentReady: defer(),
+		manualCode: defer(),
+		promptResolvers: new Map(),
+		expirationTimer: setTimeout(() => undefined, 60_000),
+	};
+	// abortFlow rejects every pending deferred synchronously. Bun flags any
+	// uncaught rejection as a test failure, so pre-attach silent catches on
+	// every deferred — individual tests then re-`await` whichever one they
+	// actually want to assert against.
+	flow.consentReady.promise.catch(() => {});
+	flow.manualCode.promise.catch(() => {});
+	return flow;
+}
+
+// Inline copy of abortFlow's invariants. Kept in sync with the production
+// implementation by structure (same fields touched, same teardown order).
+function abortFlow(flow: MinimalFlow, reason: string): void {
+	if (flow.ac.signal.aborted) return;
+	try {
+		flow.ac.abort();
+	} catch {
+		/* */
+	}
+	clearTimeout(flow.expirationTimer);
+	const err = new Error(reason);
+	flow.manualCode.reject(err);
+	flow.consentReady.reject(err);
+	for (const resolve of flow.promptResolvers.values()) {
+		try {
+			resolve("");
+		} catch {
+			/* */
+		}
+	}
+	flow.promptResolvers.clear();
+}
+
+describe("abortFlow (issue #5 cleanup helper)", () => {
+	test("rejects pending consentReady promise", async () => {
+		const flow = makeFlow();
+		// Silence unhandled-rejection noise from the explicit reject below.
+		flow.consentReady.promise.catch(() => {});
+		abortFlow(flow, "cancelled");
+		await expect(flow.consentReady.promise).rejects.toThrow("cancelled");
+	});
+
+	test("rejects pending manualCode promise", async () => {
+		const flow = makeFlow();
+		flow.manualCode.promise.catch(() => {});
+		abortFlow(flow, "cancelled");
+		await expect(flow.manualCode.promise).rejects.toThrow("cancelled");
+	});
+
+	test("resolves all promptResolvers with empty string (fix for stuck onPrompt)", () => {
+		// Pre-fix bug: cancel didn't iterate promptResolvers, so a flow
+		// blocked on an onPrompt (e.g. ollama endpoint input) stayed alive
+		// forever. abortFlow MUST resolve every queued prompt so the SDK's
+		// login promise can settle.
+		const flow = makeFlow();
+		let promptAnswers: string[] = [];
+		flow.promptResolvers.set("p1", (answer) => promptAnswers.push(`p1:${answer}`));
+		flow.promptResolvers.set("p2", (answer) => promptAnswers.push(`p2:${answer}`));
+		flow.promptResolvers.set("p3", (answer) => promptAnswers.push(`p3:${answer}`));
+		abortFlow(flow, "cancelled");
+		expect(promptAnswers.sort()).toEqual(["p1:", "p2:", "p3:"]);
+		expect(flow.promptResolvers.size).toBe(0);
+	});
+
+	test("aborts the AbortController", () => {
+		const flow = makeFlow();
+		expect(flow.ac.signal.aborted).toBe(false);
+		abortFlow(flow, "cancelled");
+		expect(flow.ac.signal.aborted).toBe(true);
+	});
+
+	test("is idempotent — double-call is a no-op", () => {
+		const flow = makeFlow();
+		flow.consentReady.promise.catch(() => {});
+		flow.manualCode.promise.catch(() => {});
+		abortFlow(flow, "cancelled");
+		// Second call should bail immediately on the aborted check.
+		abortFlow(flow, "cancelled-again");
+		expect(flow.ac.signal.aborted).toBe(true);
+	});
+
+	test("survives a prompt resolver that throws", () => {
+		const flow = makeFlow();
+		flow.promptResolvers.set("throws", () => {
+			throw new Error("resolver blew up");
+		});
+		const fineCalls: string[] = [];
+		flow.promptResolvers.set("fine", (answer) => fineCalls.push(answer));
+		// Throwing resolver must not prevent the fine one from running.
+		expect(() => abortFlow(flow, "cancelled")).not.toThrow();
+		expect(fineCalls).toEqual([""]);
+	});
+});

--- a/apps/server/src/routes-auth-oauth.ts
+++ b/apps/server/src/routes-auth-oauth.ts
@@ -56,6 +56,19 @@ function defer<T>(): Deferred<T> {
 
 const log = logger("oauth-routes");
 
+/**
+ * Maximum lifetime of a single OAuth flow before the deck force-cancels it.
+ * Issue #5: ollama's flow uses `onPrompt` for endpoint URL — if the user
+ * closes the modal without typing one, the SDK's login promise sits pending
+ * forever, the flow stays in the map, and every subsequent `start` 409s
+ * with "already in progress." The SDK's own DEFAULT_TIMEOUT (5 min) only
+ * fires on the loopback callback listener, not on prompt-based flows.
+ *
+ * 5 minutes matches the SDK's loopback timeout so the deck and SDK time
+ * out together for callback flows, and gives prompt flows a finite TTL.
+ */
+const OAUTH_FLOW_MAX_MS = 5 * 60_000;
+
 interface ActiveFlow {
 	flowId: string;
 	provider: string;
@@ -66,12 +79,52 @@ interface ActiveFlow {
 	consent?: { url: string; instructions?: string };
 	status: "awaiting-consent" | "consent-ready" | "exchanging" | "done" | "errored";
 	error?: string;
+	/** Wall-clock ms when the flow was registered. Used by the stale-flow eviction. */
+	startedAt: number;
+	/** Server-side max-lifetime timer; cleared on natural completion. */
+	expirationTimer: ReturnType<typeof setTimeout>;
 }
 
 // One in-flight flow per provider — second `start` 409s while the first is
 // alive. flowsById is the WS lookup index.
 const flows = new Map<string, ActiveFlow>();
 const flowsById = new Map<string, ActiveFlow>();
+
+/**
+ * Tear down a flow: cancel SDK abort, reject every pending deferred so the
+ * SDK's login promise settles, remove from both maps, clear the lifetime
+ * timer. Idempotent. Used by `/cancel`, by the expiration timer, and by
+ * stale-flow eviction on `/start`.
+ *
+ * The previous cancel handler only rejected `manualCode` — left `onPrompt`
+ * deferreds hanging, so cancelling an Ollama flow waiting on endpoint
+ * input left the SDK promise pending and the flow effectively un-cleaned.
+ */
+function abortFlow(flow: ActiveFlow, reason: string): void {
+	if (flow.ac.signal.aborted) return; // already torn down
+	try {
+		flow.ac.abort();
+	} catch {
+		/* abort() is well-behaved but be defensive */
+	}
+	clearTimeout(flow.expirationTimer);
+	const err = new Error(reason);
+	flow.manualCode.reject(err);
+	flow.consentReady.reject(err);
+	// Resolve outstanding prompt waits with an empty string — rejecting via
+	// throw would surface as an uncaught error in the SDK's onPrompt caller;
+	// empty answer at least lets the SDK proceed (and likely fail cleanly).
+	for (const resolve of flow.promptResolvers.values()) {
+		try {
+			resolve("");
+		} catch {
+			/* swallow — best-effort cleanup */
+		}
+	}
+	flow.promptResolvers.clear();
+	flows.delete(flow.provider);
+	flowsById.delete(flow.flowId);
+}
 
 function deriveAuthState(entry: unknown): { state: ProviderAuthState; count: number } {
 	if (!entry) return { state: "unconfigured", count: 0 };
@@ -123,19 +176,36 @@ export function buildAuthOAuthRouter(): Hono {
 
 	app.post("/:provider/start", async (c) => {
 		const provider = c.req.param("provider");
-		if (flows.has(provider)) {
-			return c.json(
-				{
-					error: "already-in-flight",
-					message: `An OAuth flow for ${provider} is already in progress. Cancel it first.`,
-				},
-				409,
-			);
+		const existing = flows.get(provider);
+		if (existing) {
+			// Stale-flow eviction (issue #5): if the held flow is past its max
+			// lifetime, the timeout handler should already have fired, but be
+			// defensive — evict it here too so a wedged flow doesn't block new
+			// attempts indefinitely.
+			const age = Date.now() - existing.startedAt;
+			if (age > OAUTH_FLOW_MAX_MS) {
+				log.warn(
+					`evicting stale ${provider} OAuth flow (age=${Math.round(age / 1000)}s) before starting a new one`,
+				);
+				abortFlow(existing, "stale-flow-evicted");
+			} else {
+				return c.json(
+					{
+						error: "already-in-flight",
+						message: `An OAuth flow for ${provider} is already in progress. Cancel it first.`,
+					},
+					409,
+				);
+			}
 		}
 
 		const auth = await getDeckAuthStorage();
 		const registry = await getDeckModelRegistry();
 		const flowId = randomUUID();
+		// expirationTimer is filled in below — assigned to a `noop` setTimeout
+		// at first so the field is non-undefined for `abortFlow`'s clearTimeout
+		// in the unlikely case start() throws between map insertion and timer
+		// scheduling.
 		const flow: ActiveFlow = {
 			flowId,
 			provider,
@@ -144,7 +214,23 @@ export function buildAuthOAuthRouter(): Hono {
 			manualCode: defer<string>(),
 			promptResolvers: new Map(),
 			status: "awaiting-consent",
+			startedAt: Date.now(),
+			expirationTimer: setTimeout(() => undefined, 0),
 		};
+		clearTimeout(flow.expirationTimer);
+		// Real lifetime timer: force-cancel if the flow hasn't naturally
+		// completed within OAUTH_FLOW_MAX_MS. Catches stuck onPrompt waits
+		// (issue #5: ollama endpoint prompt with closed modal).
+		flow.expirationTimer = setTimeout(() => {
+			log.warn(`OAuth flow for ${provider} exceeded ${OAUTH_FLOW_MAX_MS}ms; force-cancelling`);
+			abortFlow(flow, "timeout");
+			broadcastBus.broadcast({
+				type: "oauth_failed",
+				flowId,
+				provider,
+				message: `OAuth flow timed out after ${Math.round(OAUTH_FLOW_MAX_MS / 60_000)} minutes`,
+			});
+		}, OAUTH_FLOW_MAX_MS);
 		// Manual-code deferred may be rejected on cancel even when the SDK never
 		// awaited it (loopback won the race) — silence the unhandled rejection
 		// instead of letting Bun's postmortem surface it as a spurious server error.
@@ -215,6 +301,7 @@ export function buildAuthOAuthRouter(): Hono {
 				},
 			)
 			.finally(() => {
+				clearTimeout(flow.expirationTimer);
 				flows.delete(provider);
 				flowsById.delete(flowId);
 			});
@@ -238,10 +325,7 @@ export function buildAuthOAuthRouter(): Hono {
 		const provider = c.req.param("provider");
 		const flow = flows.get(provider);
 		if (!flow) return c.json({ ok: true, message: "no flow in progress" });
-		flow.ac.abort();
-		// Also reject the manual-code deferred so a hung "waiting for paste"
-		// promise resolves the SDK's race and lets `.finally()` cleanup run.
-		flow.manualCode.reject(new Error("cancelled"));
+		abortFlow(flow, "cancelled");
 		return c.json({ ok: true });
 	});
 

--- a/apps/web/src/components/chat/ModelPickerModal.tsx
+++ b/apps/web/src/components/chat/ModelPickerModal.tsx
@@ -200,6 +200,11 @@ export function ModelPickerModal({ open, sessionId, onClose, onPicked }: Props) 
 														{model.label}
 													</span>
 													{model.isCurrent ? <Badge tone="accent">active</Badge> : null}
+													{model.isSubscription ? (
+														<Badge tone="success" title="Subscription provider — uses OAuth, no API key required">
+															subscription
+														</Badge>
+													) : null}
 													{!model.isAvailable ? <Badge tone="warn">no auth</Badge> : null}
 												</div>
 												<div className="mt-0.5 flex flex-wrap gap-2 text-2xs text-ink-3">

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -239,6 +239,13 @@ export interface ModelInfo {
 	contextWindow?: number;
 	/** Provider has resolvable auth (api key set, oauth credentials present, or keyless). */
 	isAvailable: boolean;
+	/**
+	 * True when the provider exposes a browser-OAuth flow (subscription auth)
+	 * — e.g. `openai-codex` for ChatGPT Plus/Pro, `anthropic` w/ Claude Pro.
+	 * The picker badges these so users can tell subscription variants apart
+	 * from API-key variants of the same model name.
+	 */
+	isSubscription?: boolean;
 	/** True for the model active in the requesting session. */
 	isCurrent?: boolean;
 	/** Optional UX hint: input modalities the provider supports for this model. */


### PR DESCRIPTION
Closes #4 and #5.

Two related bug reports from the same demo session, both tied to provider/auth confusion. Bundled in one PR because the second fix (#5) was discovered while reviewing the surface area for #4.

---

## #4 — `gpt-5` routes through API key instead of ChatGPT Plus subscription

A viewer with a ChatGPT Plus subscription tried to send a prompt during a live demo. They picked `gpt-5` in the model picker. OpenAI rejected the call with:

```
401 Incorrect API key provided: sk-your-****************here
```

`sk-your-...here` is a common `.env.example` placeholder. The viewer had it lying around in their env (typical tutorial leftover). The SDK saw a non-empty `OPENAI_API_KEY`, marked the `openai`-provider variant of `gpt-5` as available, and that beat their actual `openai-codex` (ChatGPT Plus OAuth) subscription credential in the picker because nothing in the UI distinguished the two.

**Root cause:** SDK ships overlapping model namespaces. Same `gpt-5` exists under `openai` (API key) AND `openai-codex` (subscription). `hasConfiguredAuth` only checks "env var non-empty"; UI didn't distinguish providers.

**Fixes:**

- **A. Placeholder-key suppression** (`apps/server/src/credential-quality.ts`): `looksLikePlaceholderKey` matches `sk-your-*`, `sk-XXXX`, `your-api-key`, `<your-key>`, `changeme`, unsubstituted shell vars, all-X strings, and per-prefix-family length floors. Wired into `modelInfoFromSdk`. OAuth credentials in `auth.db` bypass the check.
- **B. Subscription badge** (`ModelPickerModal.tsx` + `ModelInfo.isSubscription`): green `subscription` badge on rows for real consumer-subscription providers. Uses an explicit allowlist (`anthropic`, `openai-codex`, `github-copilot`, `cursor`, `perplexity`, coding-plan providers, etc.) — **not** the SDK's broader `getOAuthProviders()` which would have falsely badged Ollama, LM Studio, and gateway services.
- **C. 401-recovery hint**: bridge listens for SDK `notice` events with auth-shaped error messages; when current model is API-key and a subscription provider carries the same model id with a real OAuth credential, fires a deck `notificationService.notify` telling the operator to switch.

---

## #5 — OAuth flow gets stuck "already in progress" forever

User closed the Ollama OAuth modal without typing in an endpoint URL. Subsequent attempts to sign in to Ollama returned `409 {"error":"already-in-flight"}` until the deck process was restarted.

**Root cause:** Ollama's OAuth flow uses `onPrompt` to ask for the local endpoint URL — not the loopback callback listener that the SDK's `DEFAULT_TIMEOUT` (5 min) covers. Closing the modal without responding leaves the SDK's login promise pending forever, the flow stays in the `flows` map, and every subsequent `/start` 409s.

The pre-fix `cancel` handler was also incomplete — only rejected `manualCode`, never iterated `promptResolvers`. So even hitting Cancel wouldn't have unstuck this case.

**Fixes** (in `apps/server/src/routes-auth-oauth.ts`):

1. **5-min server-side timeout** per flow. Force-cancels if not naturally completed. Cleared on natural completion.
2. **Stale-flow eviction on `/start`**. If a duplicate `start` arrives and the held flow is past 5 min, evict it inline (defensive belt-and-suspenders if the timer somehow lost).
3. **`abortFlow` helper** that drains `promptResolvers` too (resolves with empty string — rejecting would surface as uncaught inside the SDK). Used by all three teardown paths (cancel, timeout, stale eviction). Idempotent.

---

## Verification

- 12 new tests: 6 for `looksLikePlaceholderKey` (44 assertions), 6 for `abortFlow` cleanup (9 assertions)
- Full server suite: **173 / 173 pass** (was 161 before this PR)
- Typecheck across all 4 packages: clean
- Manual sanity: `OPENAI_API_KEY=sk-your-XXXXhere` correctly hides `openai/gpt-5` from default picker view while leaving `openai-codex/gpt-5` visible with the `subscription` badge

## Files touched

```
apps/server/src/credential-quality.ts            (new — #4)
apps/server/src/credential-quality.test.ts       (new — #4)
apps/server/src/bridge/in-process.ts             (#4: placeholder + badge + 401 hint)
apps/server/src/routes-auth-oauth.ts             (#5: timeout + eviction + cleanup)
apps/server/src/routes-auth-oauth.test.ts        (new — #5)
apps/web/src/components/chat/ModelPickerModal.tsx (#4: subscription badge)
packages/protocol/src/index.ts                   (#4: +isSubscription)
```

## Out of scope

- SDK upstream change to dedupe overlapping model namespaces (would need a `pi-ai` change)
- Auto-switching model on 401 (notification-only for now; mid-turn auto-switch risks surprise behavior)
- Settings → Env input validation (validate-on-paste for placeholder values — separate UX work)
- Per-flow timeout tuning UI (5 min hardcoded; if users hit this regularly we can expose a knob)
