### PR TITLE
feat(updates): in-app pill announces newer npm-published versions

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -15,6 +15,7 @@ import { closeDb, openDb } from "./db/index.ts";
 import { loadConfig } from "./config.ts";
 import { logger } from "./log.ts";
 import { resolveBunExecutable } from "./runtime-bun.ts";
+import { primeUpdateCheckOnBoot } from "./update-check.ts";
 import { buildRouter } from "./routes.ts";
 import { WsHub, type ConnectionData } from "./ws.ts";
 import { MarketplaceService } from "./marketplace-service.ts";
@@ -177,6 +178,11 @@ async function main(): Promise<void> {
 	});
 
 	log.info(`listening on http://${server.hostname}:${server.port}`);
+
+	// Background: prime the npm registry update check cache so the
+	// /api/version route returns a real answer on first call. Fire-and-
+	// forget; failures are logged and ignored.
+	primeUpdateCheckOnBoot();
 
 	let shuttingDown = false;
 	async function safeShutdown(reason: string): Promise<void> {

--- a/apps/server/src/routes.ts
+++ b/apps/server/src/routes.ts
@@ -12,6 +12,7 @@ import type {
 import type { Config } from "./config.ts";
 import { logger } from "./log.ts";
 import { getBuildInfo, getUptimeSecs } from "./build-info.ts";
+import { getUpdateCheck } from "./update-check.ts";
 import type { AgentBridge } from "./bridge/types.ts";
 
 const log = logger("routes");
@@ -62,6 +63,12 @@ export function buildRouter(
 			buildSha: info.buildSha,
 			uptimeSecs: getUptimeSecs(),
 		});
+	});
+
+	app.get("/version", async (c) => {
+		const info = getBuildInfo();
+		const body = await getUpdateCheck({ currentVersion: info.version });
+		return c.json(body);
 	});
 
 	app.get("/workspaces", async (c) => {

--- a/apps/server/src/update-check.test.ts
+++ b/apps/server/src/update-check.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Update-check tests.
+ *
+ * Coverage:
+ *   - Disabled env var short-circuits everything (no network, no cache read).
+ *   - Cache hit returns the persisted value without hitting the network.
+ *   - updateAvailable=true when cached latest > current.
+ *   - updateAvailable=false when cached latest === or < current.
+ *   - Semver-aware comparison (0.10.0 > 0.9.0; prereleases handled).
+ *   - Registry-error cache state doesn't claim an update.
+ *   - First call with no cache returns empty state and triggers background fetch.
+ *   - Response carries releaseUrl + packageUrl for the web pill.
+ *
+ * Cache-read tests use `seedCache` to write the file directly (no network),
+ * so they're deterministic and don't depend on background-refresh timing
+ * or registry reachability. Tests that exercise the network path stub
+ * `fetch` explicitly.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+	getUpdateCheck,
+	peekUpdateCacheForTests,
+	resetUpdateCheckForTests,
+} from "./update-check.ts";
+
+let savedDataDir: string | undefined;
+let savedDisable: string | undefined;
+let savedFetch: typeof fetch;
+let tmpDir: string;
+
+beforeEach(() => {
+	savedDataDir = process.env.OMP_DECK_DATA_DIR;
+	savedDisable = process.env.OMP_DECK_DISABLE_UPDATE_CHECK;
+	savedFetch = globalThis.fetch;
+	tmpDir = mkdtempSync(path.join(os.tmpdir(), "omp-deck-updatecheck-"));
+	process.env.OMP_DECK_DATA_DIR = tmpDir;
+	delete process.env.OMP_DECK_DISABLE_UPDATE_CHECK;
+	resetUpdateCheckForTests();
+});
+
+afterEach(() => {
+	if (savedDataDir === undefined) delete process.env.OMP_DECK_DATA_DIR;
+	else process.env.OMP_DECK_DATA_DIR = savedDataDir;
+	if (savedDisable === undefined) delete process.env.OMP_DECK_DISABLE_UPDATE_CHECK;
+	else process.env.OMP_DECK_DISABLE_UPDATE_CHECK = savedDisable;
+	globalThis.fetch = savedFetch;
+	try {
+		rmSync(tmpDir, { recursive: true, force: true });
+	} catch {
+		/* best-effort */
+	}
+});
+
+/**
+ * Stub fetch to return a registry-shaped response with the given latest
+ * version. Returns a small spy that records call count. `null` simulates a
+ * 503 from the registry.
+ */
+function stubRegistry(latest: string | null): { calls: number } {
+	const spy = { calls: 0 };
+	globalThis.fetch = ((_input: Parameters<typeof fetch>[0], _init?: RequestInit) => {
+		spy.calls += 1;
+		if (latest === null) {
+			return Promise.resolve(new Response("registry unreachable", { status: 503 }));
+		}
+		const body = JSON.stringify({ "dist-tags": { latest } });
+		return Promise.resolve(new Response(body, { status: 200 }));
+	}) as typeof fetch;
+	return spy;
+}
+
+/** Write the cache file directly so tests don't depend on network timing. */
+function seedCache(latest: string | null): void {
+	const file = path.join(tmpDir, "update-check.json");
+	writeFileSync(
+		file,
+		JSON.stringify(
+			{ checkedAt: new Date().toISOString(), latest, registryUrl: "test://stub" },
+			null,
+			"\t",
+		),
+		"utf8",
+	);
+}
+
+describe("update-check", () => {
+	test("disabled env var → returns disabled, no fetch", async () => {
+		process.env.OMP_DECK_DISABLE_UPDATE_CHECK = "1";
+		const spy = stubRegistry("0.7.0");
+		const res = await getUpdateCheck({ currentVersion: "0.6.0" });
+		expect(res.disabled).toBe(true);
+		expect(res.updateAvailable).toBe(false);
+		expect(res.latest).toBeNull();
+		expect(spy.calls).toBe(0);
+		expect(peekUpdateCacheForTests()).toBeUndefined();
+	});
+
+	test("disabled accepts truthy variants (1, true) but not 0/false", async () => {
+		// Stub the registry so the falsy-iterations' background fetch doesn't
+		// hit npmjs.com — we're only testing flag handling here.
+		stubRegistry(null);
+		const truthy = ["1", "true", "TRUE", "yes"];
+		const falsy = ["0", "false", "FALSE", ""];
+		for (const v of truthy) {
+			process.env.OMP_DECK_DISABLE_UPDATE_CHECK = v;
+			const res = await getUpdateCheck({ currentVersion: "0.6.0" });
+			expect({ v, disabled: res.disabled }).toEqual({ v, disabled: true });
+		}
+		for (const v of falsy) {
+			process.env.OMP_DECK_DISABLE_UPDATE_CHECK = v;
+			const res = await getUpdateCheck({ currentVersion: "0.6.0" });
+			expect({ v, disabled: res.disabled }).toEqual({ v, disabled: false });
+		}
+	});
+
+	test("cache hit with newer version → updateAvailable=true", async () => {
+		seedCache("0.7.0");
+		const res = await getUpdateCheck({ currentVersion: "0.6.0" });
+		expect(res.current).toBe("0.6.0");
+		expect(res.latest).toBe("0.7.0");
+		expect(res.updateAvailable).toBe(true);
+		expect(res.lastCheckedAt).toMatch(/\d{4}-\d{2}-\d{2}T/);
+	});
+
+	test("cache hit with same version → updateAvailable=false", async () => {
+		seedCache("0.6.0");
+		const res = await getUpdateCheck({ currentVersion: "0.6.0" });
+		expect(res.latest).toBe("0.6.0");
+		expect(res.updateAvailable).toBe(false);
+	});
+
+	test("cache hit with older version → updateAvailable=false (we're ahead)", async () => {
+		seedCache("0.5.0");
+		const res = await getUpdateCheck({ currentVersion: "0.6.0" });
+		expect(res.latest).toBe("0.5.0");
+		expect(res.updateAvailable).toBe(false);
+	});
+
+	test("semver-aware: 0.10.0 > 0.9.0 (not string-compared)", async () => {
+		seedCache("0.10.0");
+		const res = await getUpdateCheck({ currentVersion: "0.9.0" });
+		expect(res.updateAvailable).toBe(true);
+	});
+
+	test("prerelease: 1.0.0-beta < 1.0.0", async () => {
+		seedCache("1.0.0");
+		const res = await getUpdateCheck({ currentVersion: "1.0.0-beta" });
+		expect(res.updateAvailable).toBe(true);
+	});
+
+	test("registry error → cached latest:null → no update advertised", async () => {
+		seedCache(null);
+		const res = await getUpdateCheck({ currentVersion: "0.6.0" });
+		expect(res.latest).toBeNull();
+		expect(res.updateAvailable).toBe(false);
+	});
+
+	test("no cache + first call returns empty state and triggers background fetch", async () => {
+		const spy = stubRegistry("0.7.0");
+		const first = await getUpdateCheck({ currentVersion: "0.6.0" });
+		// Initial call has no cache yet.
+		expect(first.latest).toBeNull();
+		expect(first.lastCheckedAt).toBeNull();
+		expect(first.updateAvailable).toBe(false);
+		// Background refresh kicks in.
+		for (let i = 0; i < 20; i++) {
+			await new Promise((r) => setTimeout(r, 50));
+			if (peekUpdateCacheForTests()) break;
+		}
+		expect(spy.calls).toBeGreaterThan(0);
+		// Subsequent call reflects the cache.
+		const second = await getUpdateCheck({ currentVersion: "0.6.0" });
+		expect(second.latest).toBe("0.7.0");
+		expect(second.updateAvailable).toBe(true);
+	});
+
+	test("response shape includes releaseUrl + packageUrl for the web pill", async () => {
+		seedCache("0.7.0");
+		const res = await getUpdateCheck({ currentVersion: "0.6.0" });
+		expect(res.releaseUrl).toMatch(/github\.com.*releases/);
+		expect(res.packageUrl).toMatch(/npmjs\.com.*omp-deck/);
+	});
+});

--- a/apps/server/src/update-check.ts
+++ b/apps/server/src/update-check.ts
@@ -1,0 +1,256 @@
+/**
+ * Update check — polls the npm registry once per day to see whether a newer
+ * version of `omp-deck` is available. Surfaces the result through
+ * `GET /api/version`; the web layer renders a passive pill in the StatusBar
+ * when `updateAvailable === true`.
+ *
+ * Design constraints:
+ *   - **Never auto-update.** We only inform; the user decides when to run
+ *     `npm install -g omp-deck@latest`. Auto-replacing the running install
+ *     under the user is a hard no.
+ *   - **Never block the app.** The boot fetch is fire-and-forget. The
+ *     /api/version route returns the cached value immediately and triggers
+ *     a background refresh if stale.
+ *   - **Never leak telemetry.** The fetch hits npmjs.com — same destination
+ *     as the install itself. We don't include the user's version in the
+ *     request beyond the standard User-Agent (which npm itself would emit).
+ *   - **Always graceful on failure.** Registry down? Cache file corrupt?
+ *     Network proxy blocks us? Disable via env var? All paths return
+ *     `updateAvailable: false`. The pill disappears, the rest of the deck
+ *     keeps working.
+ *   - **Honors `OMP_DECK_DISABLE_UPDATE_CHECK=1`** for users on locked-down
+ *     networks or who just don't want the chrome.
+ *
+ * Cache layout (`<dataDir>/update-check.json`):
+ *   {
+ *     "checkedAt": "2026-05-29T23:00:00.000Z",
+ *     "latest": "0.7.0" | null,
+ *     "registryUrl": "https://registry.npmjs.org/omp-deck"
+ *   }
+ *
+ * `latest: null` means "we tried and got an error" — distinct from "cache
+ * empty, never fetched."
+ */
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import * as path from "node:path";
+
+import { getDataDir } from "./env-store.ts";
+import { logger } from "./log.ts";
+
+const log = logger("update-check");
+
+const REGISTRY_URL = "https://registry.npmjs.org/omp-deck";
+const PACKAGE_PAGE_URL = "https://www.npmjs.com/package/omp-deck";
+const RELEASES_URL = "https://github.com/bjb2/omp-deck/releases";
+const CACHE_FILE = "update-check.json";
+const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000; // 1 day
+const FETCH_TIMEOUT_MS = 5_000;
+
+interface CachedCheck {
+	checkedAt: string;
+	latest: string | null;
+	registryUrl: string;
+}
+
+interface UpdateCheckOptions {
+	/**
+	 * Override the running deck's version. Caller is expected to pass the
+	 * authoritative value from `build-info.ts`. Kept explicit (rather than
+	 * importing build-info here) so unit tests can swap it cleanly.
+	 */
+	currentVersion: string;
+}
+
+/** Server-facing result; serialized to the web verbatim via the route handler. */
+export interface UpdateCheckResult {
+	current: string;
+	latest: string | null;
+	updateAvailable: boolean;
+	lastCheckedAt: string | null;
+	releaseUrl: string;
+	packageUrl: string;
+	disabled: boolean;
+}
+
+function isDisabled(): boolean {
+	const raw = process.env.OMP_DECK_DISABLE_UPDATE_CHECK?.trim();
+	if (!raw) return false;
+	return raw !== "0" && raw.toLowerCase() !== "false";
+}
+
+function getCachePath(): string {
+	return path.join(getDataDir(), CACHE_FILE);
+}
+
+function readCache(): CachedCheck | undefined {
+	const p = getCachePath();
+	if (!existsSync(p)) return undefined;
+	try {
+		const parsed = JSON.parse(readFileSync(p, "utf8")) as CachedCheck;
+		if (typeof parsed.checkedAt !== "string") return undefined;
+		// `latest` may legitimately be null (means "tried and errored"); only
+		// reject if the field is missing entirely.
+		if (!("latest" in parsed)) return undefined;
+		return parsed;
+	} catch (err) {
+		log.warn(`cache read failed at ${p}`, err);
+		return undefined;
+	}
+}
+
+function writeCache(cache: CachedCheck): void {
+	const p = getCachePath();
+	try {
+		mkdirSync(path.dirname(p), { recursive: true });
+		writeFileSync(p, `${JSON.stringify(cache, null, "\t")}\n`, "utf8");
+	} catch (err) {
+		log.warn(`cache write failed at ${p}`, err);
+	}
+}
+
+function cacheIsFresh(cache: CachedCheck | undefined, now: number = Date.now()): boolean {
+	if (!cache) return false;
+	const checked = Date.parse(cache.checkedAt);
+	if (!Number.isFinite(checked)) return false;
+	return now - checked < REFRESH_INTERVAL_MS;
+}
+
+/**
+ * Hit the npm registry's package metadata endpoint, parse the version off
+ * the `dist-tags.latest` field. Returns `null` on any failure (network,
+ * timeout, bad JSON, missing field) — caller decides what to do with that.
+ * Never throws.
+ */
+async function fetchLatestFromRegistry(): Promise<string | null> {
+	const ac = new AbortController();
+	const timer = setTimeout(() => ac.abort(), FETCH_TIMEOUT_MS);
+	try {
+		const res = await fetch(REGISTRY_URL, {
+			signal: ac.signal,
+			headers: {
+				// Ask for the abbreviated metadata document — smaller payload,
+				// same `dist-tags`.
+				Accept: "application/vnd.npm.install-v1+json",
+			},
+		});
+		if (!res.ok) {
+			log.warn(`registry returned ${res.status}`);
+			return null;
+		}
+		const body = (await res.json()) as { "dist-tags"?: { latest?: unknown } };
+		const latest = body["dist-tags"]?.latest;
+		if (typeof latest !== "string" || latest.length === 0) {
+			log.warn(`registry response missing dist-tags.latest`);
+			return null;
+		}
+		return latest;
+	} catch (err) {
+		log.warn(`registry fetch failed`, err);
+		return null;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Compare two semver strings. Returns:
+ *   - negative if a < b
+ *   - 0       if a === b
+ *   - positive if a > b
+ *
+ * Wraps `Bun.semver.order` which handles prereleases, build metadata, and
+ * malformed input correctly. Returns 0 (treat as no update) when either
+ * input is unparseable — safer than guessing.
+ */
+function compareVersions(a: string, b: string): number {
+	try {
+		return Bun.semver.order(a, b);
+	} catch {
+		return 0;
+	}
+}
+
+/**
+ * Refresh the cache by hitting the registry. Best-effort: errors update the
+ * cache with `latest: null` and a fresh timestamp, so we don't hammer the
+ * registry on every page load if it's down.
+ */
+async function refreshCache(): Promise<CachedCheck> {
+	const latest = await fetchLatestFromRegistry();
+	const cache: CachedCheck = {
+		checkedAt: new Date().toISOString(),
+		latest,
+		registryUrl: REGISTRY_URL,
+	};
+	writeCache(cache);
+	if (latest) log.info(`update check refreshed: latest=${latest}`);
+	return cache;
+}
+
+/**
+ * Public: read the current update-check state. Cheap (cache-only). If the
+ * cache is stale, fires a background refresh that updates the cache for
+ * the NEXT call — never blocks this one. Disabled paths short-circuit.
+ */
+export async function getUpdateCheck(opts: UpdateCheckOptions): Promise<UpdateCheckResult> {
+	const base: UpdateCheckResult = {
+		current: opts.currentVersion,
+		latest: null,
+		updateAvailable: false,
+		lastCheckedAt: null,
+		releaseUrl: RELEASES_URL,
+		packageUrl: PACKAGE_PAGE_URL,
+		disabled: isDisabled(),
+	};
+	if (base.disabled) return base;
+
+	const cache = readCache();
+	if (cache) {
+		base.latest = cache.latest;
+		base.lastCheckedAt = cache.checkedAt;
+		base.updateAvailable =
+			cache.latest !== null && compareVersions(cache.latest, opts.currentVersion) > 0;
+	}
+
+	// Stale or never-fetched → background refresh. We don't await the
+	// promise so this call returns whatever's cached (or nothing) right now.
+	// The next call sees the fresh result.
+	if (!cacheIsFresh(cache)) {
+		void refreshCache().catch((err) => log.warn("background refresh failed", err));
+	}
+
+	return base;
+}
+
+/**
+ * Fire a refresh from server boot. The result is not used here; it just
+ * primes the cache so the first /api/version call on a fresh install
+ * returns a real answer instead of "never checked".
+ */
+export function primeUpdateCheckOnBoot(): void {
+	if (isDisabled()) return;
+	const cache = readCache();
+	if (cacheIsFresh(cache)) return;
+	// Tiny delay so boot path isn't competing for IO with whatever else is
+	// starting up. We're never blocking anything regardless.
+	setTimeout(() => {
+		void refreshCache().catch((err) => log.warn("boot refresh failed", err));
+	}, 5_000);
+}
+
+/** Test-only: wipe the cache so a test can simulate a never-checked install. */
+export function resetUpdateCheckForTests(): void {
+	const p = getCachePath();
+	if (existsSync(p)) {
+		try {
+			unlinkSync(p);
+		} catch {
+			/* best-effort */
+		}
+	}
+}
+
+/** Test-only: read the cache as-is. Returns undefined if absent. */
+export function peekUpdateCacheForTests(): CachedCheck | undefined {
+	return readCache();
+}

--- a/apps/web/src/components/chrome/StatusBar.tsx
+++ b/apps/web/src/components/chrome/StatusBar.tsx
@@ -1,4 +1,5 @@
 import { selectActiveSession, useStore } from "@/lib/store";
+import { UpdatePill } from "./UpdatePill";
 import { cn, formatTokens } from "@/lib/utils";
 
 const STATUS_TONE: Record<string, string> = {
@@ -61,6 +62,7 @@ export function StatusBar() {
 					) : null}
 				</>
 			) : null}
+			<UpdatePill />
 		</div>
 	);
 }

--- a/apps/web/src/components/chrome/UpdatePill.tsx
+++ b/apps/web/src/components/chrome/UpdatePill.tsx
@@ -1,0 +1,63 @@
+/**
+ * Update notifier pill rendered in the StatusBar. Polls `/api/version` on
+ * mount; if the server says an update is available, shows a small link
+ * pointing at the GitHub releases page so the user can read what's new
+ * and decide to upgrade.
+ *
+ * Design constraints (mirrored from `apps/server/src/update-check.ts`):
+ *
+ *   - **Hidden by default.** Renders nothing while the request is in
+ *     flight, when no update is available, when the check is disabled,
+ *     or when the server can't reach the registry. The pill only
+ *     appears when there's a real actionable update.
+ *   - **Click-through, not click-to-update.** We never trigger the
+ *     install ourselves; the user runs `npm install -g omp-deck@latest`
+ *     in their terminal. The link opens the releases page in a new tab
+ *     so they can read the changelog first.
+ *   - **One fetch per mount.** No polling, no WS subscription. Update
+ *     announcements aren't real-time; checking again on the next page
+ *     load is enough.
+ */
+import { useEffect, useState } from "react";
+import { ArrowUpCircle } from "lucide-react";
+
+import type { VersionInfo } from "@omp-deck/protocol";
+
+export function UpdatePill() {
+	const [info, setInfo] = useState<VersionInfo | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		void fetch("/api/version")
+			.then((r) => (r.ok ? (r.json() as Promise<VersionInfo>) : null))
+			.then((data) => {
+				if (cancelled) return;
+				setInfo(data);
+			})
+			.catch(() => {
+				// Probe failed (network blip, server bouncing) — leave info null.
+				// User just sees no pill; the next page load retries.
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	if (!info || info.disabled || !info.updateAvailable || !info.latest) return null;
+
+	return (
+		<>
+			<span className="text-ink-4">·</span>
+			<a
+				href={info.releaseUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				title={`Running ${info.current} — ${info.latest} available. Click to view release notes.`}
+				className="flex items-center gap-1 text-accent hover:text-accent/80"
+			>
+				<ArrowUpCircle className="h-3 w-3" />
+				<span>{info.latest} available</span>
+			</a>
+		</>
+	);
+}

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -299,6 +299,32 @@ export interface SeedKbSystemResponse {
 	skipped: string[];
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Update check
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Composite response for `GET /api/version`. The web layer renders a
+ * passive pill in the StatusBar when `updateAvailable === true`.
+ *
+ * Failure modes are baked into the type, not exceptions:
+ *   - `disabled: true` — `OMP_DECK_DISABLE_UPDATE_CHECK` is set; the deck
+ *     never hits the registry. Web should hide the pill entirely.
+ *   - `latest: null` — registry was unreachable, response malformed, or
+ *     no fetch has succeeded yet. Web should hide the pill.
+ *   - `updateAvailable: false` with non-null `latest` — running version
+ *     is already at or above the published latest.
+ */
+export interface VersionInfo {
+	current: string;
+	latest: string | null;
+	updateAvailable: boolean;
+	lastCheckedAt: string | null;
+	releaseUrl: string;
+	packageUrl: string;
+	disabled: boolean;
+}
+
 export interface SetSessionModelRequest {
 	model: ModelRef;
 }


### PR DESCRIPTION
## What it does

A small `↑ 0.7.0 available` pill appears in the StatusBar (bottom of the deck) when a newer version of omp-deck has been published to npm. Click it → opens GitHub releases in a new tab → user reads what changed → user updates manually with `npm install -g omp-deck@latest`.

That's the entire feature. No auto-update, no nag dialog, no telemetry.

## Design constraints

| | |
|---|---|
| Never auto-updates | We inform; the user runs the install. Auto-replacing a running install is out of scope. |
| Never blocks the app | Boot fires fire-and-forget cache prime. `/api/version` returns the cached value immediately and triggers a background refresh if stale. |
| Never leaks telemetry | Fetches `https://registry.npmjs.org/omp-deck` with the abbreviated metadata Accept header. Same destination as `npm install` itself. No version-as-fingerprint, no analytics. |
| Always graceful on failure | Registry down, corrupt cache, unparseable response, env-disabled → all paths return `updateAvailable: false` and the pill stays hidden. |
| Disable knob | `OMP_DECK_DISABLE_UPDATE_CHECK=1` short-circuits everything (no cache read, no network). Documented in CHANGELOG when shipped. |

## Cache layout

`<dataDir>/update-check.json`:

```json
{ "checkedAt": "ISO-timestamp", "latest": "0.7.0", "registryUrl": "..." }
```

24-hour refresh interval. `latest: null` distinguishes "tried and errored" from "never fetched" — neither shows a pill.

## Semver-awareness

Uses `Bun.semver.order` for comparison so:
- `0.10.0 > 0.9.0` (not lexicographic)
- `1.0.0-beta < 1.0.0` (prerelease handling)
- malformed input returns 0 (treat as no update — safer than guessing)

## Files

```
apps/server/src/update-check.ts             (new, ~250 LOC — fetch, cache, compare)
apps/server/src/update-check.test.ts        (new, 10 tests, 33 assertions)
apps/server/src/routes.ts                   GET /api/version wiring
apps/server/src/index.ts                    primeUpdateCheckOnBoot() in main()
apps/web/src/components/chrome/UpdatePill.tsx  (new — fetch on mount, render only if updateAvailable)
apps/web/src/components/chrome/StatusBar.tsx   <UpdatePill /> placement
packages/protocol/src/index.ts              VersionInfo type
```

## Verification

- 10 new unit tests cover: disabled env var (truthy/falsy variants), cache hit with newer/same/older versions, semver-aware comparison, prerelease handling, registry-error state, first-call empty state + background refresh, response shape (releaseUrl + packageUrl present)
- Stubbed `globalThis.fetch` for network paths; `seedCache` writes the cache directly for cache-read paths — no test depends on registry reachability or background-refresh timing
- Full server suite: **191/191 pass** (was 181)
- Typecheck across all 4 packages: clean

## Out of scope (possible follow-ups)

- Settings panel to toggle the kill switch from the UI (env var is the only way today)
- Release-notes excerpt in a hover tooltip
- Notification toast on first detection (currently pill-only; intentional restraint — toast could feel spammy)
